### PR TITLE
Update _layout.js

### DIFF
--- a/app/(drawer)/_layout.js
+++ b/app/(drawer)/_layout.js
@@ -109,7 +109,7 @@ const CustomDrawerContent = (props) => {
 
 export default function Layout() {
   return (
-    <Drawer drawerContent={(props) => <CustomDrawerContent {...props} />} screenOptions={{headerShown: false}}>
+    <Drawer drawerContent={(props) => <CustomDrawerContent {...props} />} screenOptions={{headerShown: false}} backBehavior='history'>
       <Drawer.Screen name="favourites" options={{headerShown: true}} />
       <Drawer.Screen name="settings" options={{headerShown: true}} />
     </Drawer>


### PR DESCRIPTION
This will resolve an issue where when clicking on the back button in an Android device, you are being redirected to the first Drawer.Screen (in your case /favourites) instead of the actual history of the stack.